### PR TITLE
fix: Update model path of model_monitoring_for_custom_model_online_pr…

### DIFF
--- a/notebooks/official/model_monitoring_v2/model_monitoring_for_custom_model_online_prediction.ipynb
+++ b/notebooks/official/model_monitoring_v2/model_monitoring_for_custom_model_online_prediction.ipynb
@@ -335,7 +335,7 @@
       "source": [
         "import google.cloud.aiplatform as aiplatform\n",
         "\n",
-        "MODEL_PATH = \"gs://mco-mm/churn\"\n",
+        "MODEL_PATH = \"gs://cloud-samples-data/vertex-ai/model-deployment/models/churn\"\n",
         "MODEL_NAME = \"churn\"\n",
         "IMAGE = \"us-docker.pkg.dev/cloud-aiplatform/prediction/tf2-cpu.2-5:latest\"\n",
         "\n",


### PR DESCRIPTION
…ediction.ipynb

Update the unavailable model path for model_monitoring_for_custom_model_online_prediction.ipynb

**REQUIRED:** Update the gcs uri of model path in this notebook as the original one is no longer available.
